### PR TITLE
Improve artwork buying experience

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,8 @@ nav:
   links:
   - title: Available Work
     url: /portfolio/
+  - title: Buying Art
+    url: /buying.html
   - title: Commissions
     url: /commissions.html
   - title: About

--- a/_includes/work-card.html
+++ b/_includes/work-card.html
@@ -9,7 +9,7 @@
          data-series="{{ series_slug }}"
          itemscope
          itemtype="https://schema.org/VisualArtwork">
-  <a class="work-card__link" href="{{ work.url | relative_url }}" aria-label="View {{ work.title | escape }}">
+  <a class="work-card__link" href="{{ work.url | relative_url }}" aria-label="View details for {{ work.title | escape }}">
     <div class="work-card__media">
       {%- if work.image -%}
         <img src="{{ work.image | relative_url }}"
@@ -41,8 +41,13 @@
           {%- if work.medium -%}{{ work.medium }}{%- endif -%}
         </p>
       {%- endif -%}
-      {%- if work.price and work.price != blank -%}<p class="work-card__price">{{ work.price }}</p>{%- endif -%}
+      {%- if work.status == 'Available' -%}
+        <p class="work-card__price">{% if work.price and work.price != blank %}{{ work.price }}{% else %}Price on request{% endif %}</p>
+      {%- elsif work.price and work.price != blank -%}
+        <p class="work-card__price">{{ work.price }}</p>
+      {%- endif -%}
       {%- if work.subtitle -%}<p class="work-card__desc">{{ work.subtitle }}</p>{%- endif -%}
+      <span class="work-card__cta">View artwork details <span aria-hidden="true">→</span></span>
     </div>
   </a>
 </article>

--- a/_layouts/portfolio-gallery.html
+++ b/_layouts/portfolio-gallery.html
@@ -13,7 +13,8 @@ layout: default
         <p class="lede muted">{{ page.intro }}</p>
       {% endif %}
       <div class="gallery-actions">
-        <a class="btn" href="mailto:{{ site.email }}?subject=Artwork%20inquiry">Artwork inquiry</a>
+        <a class="btn" href="#available-work">View available work</a>
+        <a class="btn ghost" href="{{ '/buying.html' | relative_url }}">How to buy original art</a>
         <a class="btn ghost" href="{{ '/commissions.html' | relative_url }}">Commission a work</a>
       </div>
     </div>
@@ -35,13 +36,32 @@ layout: default
   </div>
 </section>
 
+<section class="collector-assurances" aria-label="Collector information">
+  <div class="wrapper collector-assurances__grid">
+    <div>
+      <strong>Documented originals</strong>
+      <span>Signed works include an inventory record and certificate of authenticity unless noted.</span>
+    </div>
+    <div>
+      <strong>See the true scale</strong>
+      <span>Dimensions and depth are listed, and room-view mockups can be prepared for serious inquiries.</span>
+    </div>
+    <div>
+      <strong>Clear fulfillment</strong>
+      <span>Austin pickup is available. Delivery and insured shipping are quoted before payment.</span>
+    </div>
+  </div>
+</section>
+
 {% if content and content != blank %}
   <div class="wrapper gallery-introduction">
     {{ content }}
   </div>
 {% endif %}
 
-{% include portfolio-gallery.html %}
+<div id="available-work">
+  {% include portfolio-gallery.html %}
+</div>
 
 <script>
   (() => {

--- a/_layouts/work.html
+++ b/_layouts/work.html
@@ -16,17 +16,38 @@ layout: default
 
   <section class="work-body">
     <div class="wrapper work-grid">
-      <figure class="work-media">
-        {% if page.image %}
-          <img src="{{ page.image | relative_url }}" alt="{{ page.alt | default: page.title | escape }}" loading="eager" decoding="async" fetchpriority="high" itemprop="image">
+      <div class="work-gallery" aria-label="Artwork views">
+        {% if page.gallery and page.gallery.size > 0 %}
+          {% for view in page.gallery %}
+            <figure class="work-media{% if forloop.first %} work-media--primary{% endif %}">
+              <img src="{{ view.image | relative_url }}"
+                   alt="{{ view.alt | default: page.alt | default: page.title | escape }}"
+                   loading="{% if forloop.first %}eager{% else %}lazy{% endif %}"
+                   decoding="async"
+                   {% if forloop.first %}fetchpriority="high" itemprop="image"{% endif %}>
+              {% if view.label %}<figcaption>{{ view.label }}</figcaption>{% endif %}
+            </figure>
+          {% endfor %}
+        {% elsif page.image %}
+          <figure class="work-media work-media--primary">
+            <img src="{{ page.image | relative_url }}" alt="{{ page.alt | default: page.title | escape }}" loading="eager" decoding="async" fetchpriority="high" itemprop="image">
+          </figure>
         {% else %}
-          <div class="work-media__placeholder" role="img" aria-label="Photograph pending for {{ page.title | escape }}">
-            <span>Artwork photograph pending</span>
+          <div class="work-media work-media--primary">
+            <div class="work-media__placeholder" role="img" aria-label="Photograph pending for {{ page.title | escape }}">
+              <span>Artwork photograph pending</span>
+            </div>
           </div>
         {% endif %}
-      </figure>
 
-      <aside class="work-panel" aria-label="Artwork details">
+        {% if page.room_preview_note %}
+          <p class="work-gallery__note muted">{{ page.room_preview_note }}</p>
+        {% elsif page.status == 'Available' %}
+          <p class="work-gallery__note muted">Need help judging scale? Request a room-view mockup using a photograph of your wall.</p>
+        {% endif %}
+      </div>
+
+      <aside class="work-panel" aria-label="Artwork and purchasing details">
         <div class="work-details">
           <h2 class="sr-only">Artwork details</h2>
           <dl>
@@ -35,26 +56,52 @@ layout: default
             {% if page.status %}<div><dt>Status</dt><dd>{{ page.status }}</dd></div>{% endif %}
             {% if page.size %}<div><dt>Dimensions</dt><dd>{{ page.size }}</dd></div>{% endif %}
             {% if page.medium %}<div><dt>Medium</dt><dd itemprop="artMedium">{{ page.medium }}</dd></div>{% endif %}
+            {% if page.surface %}<div><dt>Surface</dt><dd>{{ page.surface }}</dd></div>{% endif %}
             {% if page.finish %}<div><dt>Finish</dt><dd>{{ page.finish }}</dd></div>{% endif %}
+            {% if page.framing %}<div><dt>Framing</dt><dd>{{ page.framing }}</dd></div>{% endif %}
+            {% if page.hanging %}<div><dt>Hanging</dt><dd>{{ page.hanging }}</dd></div>{% endif %}
             {% if page.inventory_id %}<div><dt>Inventory ID</dt><dd>{{ page.inventory_id }}</dd></div>{% endif %}
-            {% if page.price and page.price != blank %}<div><dt>Price</dt><dd>{{ page.price }}</dd></div>{% endif %}
+            {% if page.status == 'Available' %}
+              <div class="work-price-row">
+                <dt>Price</dt>
+                <dd class="work-price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+                  {% if page.price and page.price != blank %}
+                    <span itemprop="price">{{ page.price }}</span>
+                    <meta itemprop="priceCurrency" content="USD">
+                  {% else %}
+                    Price on request
+                  {% endif %}
+                  <link itemprop="availability" href="https://schema.org/InStock">
+                </dd>
+              </div>
+            {% elsif page.price and page.price != blank %}
+              <div><dt>Price</dt><dd>{{ page.price }}</dd></div>
+            {% endif %}
             {% if page.note %}<div><dt>Notes</dt><dd>{{ page.note }}</dd></div>{% endif %}
           </dl>
         </div>
 
         <div class="work-actions">
           {% assign subject = page.title | uri_escape %}
+          {% assign inventory = page.inventory_id | default: 'Not listed' | uri_escape %}
           {% if page.status == 'Available' %}
-            <a class="btn" href="mailto:{{ site.email }}?subject=Artwork%20inquiry:%20{{ subject }}">Inquire about this work</a>
+            <a class="btn" href="mailto:{{ site.email }}?subject=Artwork%20inquiry:%20{{ subject }}&body=Hello%20Robert,%0A%0AI%20am%20interested%20in%20{{ subject }}%20({{ inventory }}).%20Please%20send%20current%20availability,%20purchase,%20pickup,%20and%20shipping%20details.%0A%0AThank%20you.">Inquire about this work</a>
           {% else %}
-            <a class="btn" href="mailto:{{ site.email }}?subject=Commission%20inspired%20by:%20{{ subject }}">Ask about related work</a>
+            <a class="btn" href="mailto:{{ site.email }}?subject=Related%20work:%20{{ subject }}&body=Hello%20Robert,%0A%0AI%20am%20interested%20in%20work%20related%20to%20{{ subject }}.%20Please%20let%20me%20know%20about%20available%20pieces%20or%20commission%20options.%0A%0AThank%20you.">Ask about related work</a>
           {% endif %}
+          <a class="btn ghost" href="{{ '/buying.html' | relative_url }}">How purchasing works</a>
           <a class="btn ghost" href="{{ '/portfolio/' | relative_url }}">Back to portfolio</a>
         </div>
 
-        <p class="work-small muted">
-          Original works include a certificate of authenticity when applicable. Austin pickup is preferred; delivery or shipping is quoted case by case.
-        </p>
+        <div class="work-assurances" aria-label="Purchase assurances">
+          <h2>Included with original works</h2>
+          <ul>
+            <li>Signed artwork and documented inventory record</li>
+            <li>Certificate of authenticity unless specifically noted</li>
+            <li>Condition and hanging details confirmed before payment</li>
+            <li>Austin pickup available; delivery or shipping quoted separately</li>
+          </ul>
+        </div>
       </aside>
     </div>
 

--- a/_layouts/work.html
+++ b/_layouts/work.html
@@ -64,14 +64,8 @@ layout: default
             {% if page.status == 'Available' %}
               <div class="work-price-row">
                 <dt>Price</dt>
-                <dd class="work-price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                  {% if page.price and page.price != blank %}
-                    <span itemprop="price">{{ page.price }}</span>
-                    <meta itemprop="priceCurrency" content="USD">
-                  {% else %}
-                    Price on request
-                  {% endif %}
-                  <link itemprop="availability" href="https://schema.org/InStock">
+                <dd class="work-price">
+                  {% if page.price and page.price != blank %}{{ page.price }}{% else %}Price on request{% endif %}
                 </dd>
               </div>
             {% elsif page.price and page.price != blank %}
@@ -85,9 +79,9 @@ layout: default
           {% assign subject = page.title | uri_escape %}
           {% assign inventory = page.inventory_id | default: 'Not listed' | uri_escape %}
           {% if page.status == 'Available' %}
-            <a class="btn" href="mailto:{{ site.email }}?subject=Artwork%20inquiry:%20{{ subject }}&body=Hello%20Robert,%0A%0AI%20am%20interested%20in%20{{ subject }}%20({{ inventory }}).%20Please%20send%20current%20availability,%20purchase,%20pickup,%20and%20shipping%20details.%0A%0AThank%20you.">Inquire about this work</a>
+            <a class="btn" href="mailto:{{ site.email }}?subject=Artwork%20inquiry:%20{{ subject }}&amp;body=Hello%20Robert,%0A%0AI%20am%20interested%20in%20{{ subject }}%20({{ inventory }}).%20Please%20send%20current%20availability,%20purchase,%20pickup,%20and%20shipping%20details.%0A%0AThank%20you.">Inquire about this work</a>
           {% else %}
-            <a class="btn" href="mailto:{{ site.email }}?subject=Related%20work:%20{{ subject }}&body=Hello%20Robert,%0A%0AI%20am%20interested%20in%20work%20related%20to%20{{ subject }}.%20Please%20let%20me%20know%20about%20available%20pieces%20or%20commission%20options.%0A%0AThank%20you.">Ask about related work</a>
+            <a class="btn" href="mailto:{{ site.email }}?subject=Related%20work:%20{{ subject }}&amp;body=Hello%20Robert,%0A%0AI%20am%20interested%20in%20work%20related%20to%20{{ subject }}.%20Please%20let%20me%20know%20about%20available%20pieces%20or%20commission%20options.%0A%0AThank%20you.">Ask about related work</a>
           {% endif %}
           <a class="btn ghost" href="{{ '/buying.html' | relative_url }}">How purchasing works</a>
           <a class="btn ghost" href="{{ '/portfolio/' | relative_url }}">Back to portfolio</a>

--- a/_works/conjunction-at-the-red-shore.md
+++ b/_works/conjunction-at-the-red-shore.md
@@ -7,7 +7,8 @@ size: 20×24×1.5 in
 medium: Acrylic on canvas
 finish: Gamblin Gamvar Matte varnish
 inventory_id: RGA-CRS-2026-01
-image: assets/images/robert_grantham_conjunction_red_shore_1.jpg  
+price: "$500"
+image: assets/images/robert_grantham_conjunction_red_shore_1.jpg
 alt: Conjunction at the Red Shore — abstract acrylic painting with circular bodies crossing warm red and yellow fields above a deep blue shore
 subtitle: Orb-like bodies cross a heated field above a blue boundary that reads as shore, fracture, and threshold.
 section: Conjunctions
@@ -15,7 +16,7 @@ order: 3
 featured: false
 note: Current revised state documented July 2026. COA included.
 permalink: /portfolio/conjunction-at-the-red-shore/
-description: Conjunction at the Red Shore — a 20×24×1.5 inch original acrylic painting from Robert Grantham's Conjunctions series. Available.
+description: Conjunction at the Red Shore — a 20×24×1.5 inch original acrylic painting from Robert Grantham's Conjunctions series. Available for $500.
 ---
 
 In *Conjunction at the Red Shore*, warm yellow and red-orange fields press against a deep blue boundary while overlapping circular bodies create pressure, movement, and celestial scale. The pale broken line at the boundary can be read as surf, fracture, illuminated seam, or all three at once.

--- a/_works/threshold-of-heat.md
+++ b/_works/threshold-of-heat.md
@@ -2,7 +2,7 @@
 title: Threshold of Heat
 year: 2026
 series: Threshold
-status: Available
+status: Sold
 size: 12×12 in (5/8 in depth)
 medium: Acrylic on canvas
 finish: Matte varnish
@@ -13,7 +13,7 @@ subtitle: A charged red field where pressure, structure, and heat push against o
 section: Threshold
 order: 1
 featured: true
-note: COA included.
+note: Sold. COA included.
 permalink: /portfolio/threshold-of-heat/
 ---
 

--- a/_works/threshold-of-night.md
+++ b/_works/threshold-of-night.md
@@ -2,7 +2,7 @@
 title: Threshold of Night
 year: 2026
 series: Threshold
-status: Available
+status: Sold
 size: 12×12 in (5/8 in depth)
 medium: Acrylic on canvas
 finish: Matte varnish
@@ -12,8 +12,8 @@ alt: Threshold of Night — abstract acrylic painting in blue and dark tones wit
 subtitle: A blue-toned meditation on depth, atmosphere, and the architecture of darkness.
 section: Threshold
 order: 2
-featured: false 
-note: COA included.
+featured: false
+note: Sold. COA included.
 permalink: /portfolio/threshold-of-night/
 ---
 

--- a/assets/css/buying.css
+++ b/assets/css/buying.css
@@ -1,0 +1,55 @@
+.buying-hero {
+  max-width: 78rem;
+}
+
+.buying-hero h1 {
+  max-width: 18ch;
+  margin-top: 1rem;
+  font-size: clamp(2.8rem, 6vw, 5.2rem);
+  line-height: .98;
+}
+
+.buying-hero .lede {
+  max-width: 72ch;
+  line-height: 1.75;
+}
+
+.buying-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin-top: 1.5rem;
+}
+
+.buying-section {
+  padding-top: clamp(2.5rem, 6vw, 4.5rem);
+}
+
+.buying-section .card h2,
+.buying-section .card h3 {
+  margin-top: .75rem;
+}
+
+.buying-section .card p:last-child,
+.buying-section .card ul:last-child {
+  margin-bottom: 0;
+}
+
+.buying-section ul {
+  display: grid;
+  gap: .65rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+.buying-signup {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, var(--card));
+}
+
+@media (max-width: 560px) {
+  .buying-actions .btn,
+  .buying-signup .btn {
+    width: 100%;
+  }
+}

--- a/assets/css/curated-portfolio.css
+++ b/assets/css/curated-portfolio.css
@@ -59,12 +59,44 @@
   line-height: 1;
 }
 
+.collector-assurances {
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.collector-assurances__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  background: var(--border);
+}
+
+.collector-assurances__grid > div {
+  display: grid;
+  gap: .35rem;
+  padding: 1.25rem;
+  background: var(--bg);
+}
+
+.collector-assurances strong {
+  color: var(--fg);
+}
+
+.collector-assurances span {
+  color: var(--muted);
+  font-size: .9rem;
+  line-height: 1.55;
+}
+
 .gallery-introduction {
   padding-top: 2rem;
 }
 
 .gallery-block {
   padding: clamp(2.5rem, 6vw, 5rem) 0 clamp(4rem, 8vw, 7rem);
+  scroll-margin-top: 6rem;
 }
 
 .gallery-toolbar {
@@ -143,6 +175,26 @@
   display: none;
 }
 
+.work-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  margin-top: auto;
+  padding-top: 1rem;
+  color: var(--fg);
+  font-size: .86rem;
+  font-weight: 750;
+}
+
+.work-card:hover .work-card__cta span,
+.work-card:focus-within .work-card__cta span {
+  transform: translateX(3px);
+}
+
+.work-card__cta span {
+  transition: transform .18s ease;
+}
+
 .empty-gallery {
   margin-top: 2rem;
   text-align: center;
@@ -164,6 +216,10 @@
 
   .gallery-summary {
     max-width: 42rem;
+  }
+
+  .collector-assurances__grid {
+    grid-template-columns: 1fr;
   }
 
   .work-grid {
@@ -197,7 +253,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .gallery-filter {
+  .gallery-filter,
+  .work-card__cta span {
     transition: none;
   }
 }

--- a/assets/css/work.css
+++ b/assets/css/work.css
@@ -58,9 +58,16 @@
   align-items: start;
 }
 
+.work-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  min-width: 0;
+}
+
 .work-media {
   display: grid;
-  min-height: 420px;
+  min-height: 260px;
   place-items: center;
   margin: 0;
   overflow: hidden;
@@ -70,10 +77,35 @@
   background: var(--card);
 }
 
+.work-media--primary,
+.work-gallery__note {
+  grid-column: 1 / -1;
+}
+
+.work-media--primary {
+  min-height: 420px;
+}
+
 .work-media img {
   width: 100%;
   max-height: 78vh;
   object-fit: contain;
+}
+
+.work-media figcaption {
+  width: 100%;
+  margin-top: .8rem;
+  color: var(--muted);
+  font-size: .82rem;
+  text-align: left;
+}
+
+.work-gallery__note {
+  margin: 0;
+  padding: .85rem 1rem;
+  border-left: 3px solid var(--accent);
+  background: var(--card);
+  font-size: .9rem;
 }
 
 .work-media__placeholder {
@@ -132,11 +164,36 @@
   margin: 0;
 }
 
+.work-price {
+  color: var(--fg);
+  font-weight: 800;
+}
+
 .work-actions {
   display: flex;
   flex-direction: column;
   gap: .65rem;
   margin-top: 1.25rem;
+}
+
+.work-assurances {
+  margin-top: 1.35rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--border);
+}
+
+.work-assurances h2 {
+  margin-bottom: .65rem;
+  font-size: 1rem;
+}
+
+.work-assurances ul {
+  display: grid;
+  gap: .55rem;
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--muted);
+  font-size: .86rem;
 }
 
 .work-small {
@@ -169,7 +226,12 @@
 }
 
 @media (max-width: 560px) {
+  .work-gallery {
+    grid-template-columns: 1fr;
+  }
+
   .work-media,
+  .work-media--primary,
   .work-media__placeholder {
     min-height: 300px;
   }

--- a/buying.html
+++ b/buying.html
@@ -1,0 +1,65 @@
+---
+layout: default
+title: Buying Original Art
+description: How to inquire about, evaluate, purchase, pick up, or ship an original painting by Austin artist Robert Grantham.
+permalink: /buying.html
+---
+<section class="wrapper">
+  <span class="tag">Collector guide</span>
+  <h1>Buying an original should be clear, not mysterious.</h1>
+  <p class="lede">Each available artwork page provides the dimensions, medium, finish, inventory number, availability, and either a listed price or a direct way to request it. There is no need to decode gallery smoke signals or perform a ceremonial dance before asking a practical question.</p>
+
+  <div class="gallery-actions">
+    <a class="btn" href="{{ '/portfolio/#available' | relative_url }}">View available work</a>
+    <a class="btn ghost" href="mailto:{{ site.email }}?subject=Original%20art%20inquiry">Ask a purchasing question</a>
+  </div>
+</section>
+
+<section class="wrapper" style="padding-top: 3rem;">
+  <h2>How the purchase process works</h2>
+  <div class="grid three">
+    <article class="card">
+      <span class="tag">1 · Choose</span>
+      <h3>Review the artwork record</h3>
+      <p>Open the individual artwork page to confirm size, depth, medium, finish, availability, price information, and the work’s inventory number.</p>
+    </article>
+    <article class="card">
+      <span class="tag">2 · Confirm</span>
+      <h3>Ask what the screen cannot answer</h3>
+      <p>Request detail photographs, side and rear views, a condition confirmation, or a scaled room-view mockup. Serious questions are welcome; surprise is a poor interior-design strategy.</p>
+    </article>
+    <article class="card">
+      <span class="tag">3 · Complete</span>
+      <h3>Arrange payment and delivery</h3>
+      <p>The final total and fulfillment method are confirmed before payment. Austin pickup is available. Local delivery or insured shipping is quoted according to the work and destination.</p>
+    </article>
+  </div>
+</section>
+
+<section class="wrapper" style="padding-top: 3rem;">
+  <div class="grid two">
+    <article class="card">
+      <h2>What accompanies an original</h2>
+      <ul>
+        <li>The signed original artwork</li>
+        <li>A documented title, year, medium, dimensions, and inventory number</li>
+        <li>A certificate of authenticity unless the artwork page states otherwise</li>
+        <li>Condition, finish, and hanging information confirmed before purchase</li>
+      </ul>
+    </article>
+
+    <article class="card">
+      <h2>Evaluating scale and placement</h2>
+      <p>Measurements on a screen can be perfectly accurate and still feel abstract. For a serious inquiry, send a straight-on photograph of the intended wall and its width. A scaled mockup can then show the artwork at its actual proportions.</p>
+      <p>Mockups are planning aids rather than magical prophecies: screen color, room lighting, and camera perspective can differ from the physical work.</p>
+    </article>
+  </div>
+</section>
+
+<section class="wrapper" style="padding-top: 3rem;">
+  <div class="card">
+    <h2>Join the collector and studio update list</h2>
+    <p>Receive occasional notices about newly available paintings, exhibitions, small works, and studio developments. This is a personal studio list, not a daily electronic woodpecker.</p>
+    <a class="btn" href="mailto:{{ site.email }}?subject=Add%20me%20to%20Robert%20Grantham%20Art%20updates&body=Hello%20Robert,%0A%0APlease%20add%20me%20to%20your%20collector%20and%20studio%20update%20list.%0A%0AName:%0ACity:%0AArt%20interests%20(optional):%0A">Request studio updates</a>
+  </div>
+</section>

--- a/buying.html
+++ b/buying.html
@@ -3,19 +3,20 @@ layout: default
 title: Buying Original Art
 description: How to inquire about, evaluate, purchase, pick up, or ship an original painting by Austin artist Robert Grantham.
 permalink: /buying.html
+css: /assets/css/buying.css
 ---
-<section class="wrapper">
+<section class="wrapper buying-hero">
   <span class="tag">Collector guide</span>
   <h1>Buying an original should be clear, not mysterious.</h1>
   <p class="lede">Each available artwork page provides the dimensions, medium, finish, inventory number, availability, and either a listed price or a direct way to request it. There is no need to decode gallery smoke signals or perform a ceremonial dance before asking a practical question.</p>
 
-  <div class="gallery-actions">
+  <div class="buying-actions">
     <a class="btn" href="{{ '/portfolio/#available' | relative_url }}">View available work</a>
     <a class="btn ghost" href="mailto:{{ site.email }}?subject=Original%20art%20inquiry">Ask a purchasing question</a>
   </div>
 </section>
 
-<section class="wrapper" style="padding-top: 3rem;">
+<section class="wrapper buying-section">
   <h2>How the purchase process works</h2>
   <div class="grid three">
     <article class="card">
@@ -36,7 +37,7 @@ permalink: /buying.html
   </div>
 </section>
 
-<section class="wrapper" style="padding-top: 3rem;">
+<section class="wrapper buying-section">
   <div class="grid two">
     <article class="card">
       <h2>What accompanies an original</h2>
@@ -56,10 +57,10 @@ permalink: /buying.html
   </div>
 </section>
 
-<section class="wrapper" style="padding-top: 3rem;">
-  <div class="card">
+<section class="wrapper buying-section">
+  <div class="card buying-signup">
     <h2>Join the collector and studio update list</h2>
     <p>Receive occasional notices about newly available paintings, exhibitions, small works, and studio developments. This is a personal studio list, not a daily electronic woodpecker.</p>
-    <a class="btn" href="mailto:{{ site.email }}?subject=Add%20me%20to%20Robert%20Grantham%20Art%20updates&body=Hello%20Robert,%0A%0APlease%20add%20me%20to%20your%20collector%20and%20studio%20update%20list.%0A%0AName:%0ACity:%0AArt%20interests%20(optional):%0A">Request studio updates</a>
+    <a class="btn" href="mailto:{{ site.email }}?subject=Add%20me%20to%20Robert%20Grantham%20Art%20updates&amp;body=Hello%20Robert,%0A%0APlease%20add%20me%20to%20your%20collector%20and%20studio%20update%20list.%0A%0AName:%0ACity:%0AArt%20interests%20(optional):%0A">Request studio updates</a>
   </div>
 </section>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,10 +1,10 @@
 ---
 layout: portfolio-gallery
 title: Portfolio
-heading: Selected works
+heading: Original paintings available from the studio
 kicker: Robert Grantham Art
-intro: "Original acrylic paintings and calligraphic abstractions rooted in memory, pressure, resilience, and place. Use the filters to view available works, sold works, or a particular series."
-description: "Selected original acrylic paintings and calligraphic abstractions by Austin artist Robert Grantham, including currently available and sold works."
+intro: "Browse original acrylic paintings and calligraphic abstractions rooted in memory, pressure, resilience, and place. Each artwork record includes dimensions, materials, availability, pricing information, and a direct inquiry route."
+description: "Available and sold original acrylic paintings by Austin artist Robert Grantham, with dimensions, materials, prices or price-inquiry details, and collector information."
 permalink: /portfolio/
 css: /assets/css/curated-portfolio.css
 ---


### PR DESCRIPTION
## What changed
- added clearer portfolio calls to action and collector assurances
- added a dedicated buying guide with inquiry and studio-update links
- improved artwork detail pages with price-on-request handling, purchase assurances, room-mockup guidance, and support for multiple artwork views
- added clearer portfolio-card pricing and detail links
- marked both Threshold paintings sold
- listed Conjunction at the Red Shore at the current $500 price

## Why
The portfolio already presented the work well, but it left several common buyer questions unanswered. These changes reduce purchasing uncertainty while preserving the site’s existing visual identity and Jekyll structure.

## Validation
- compared the branch against main; 12 intended files changed and no unrelated files were touched
- reviewed Liquid conditionals, relative links, mailto links, responsive CSS, and collection fields for GitHub Pages compatibility
- retained fallbacks for works without listed prices or additional gallery images
- confirmed the pull request is mergeable; this repository has no configured commit-status checks